### PR TITLE
Basic Wii support

### DIFF
--- a/include/cxx.h
+++ b/include/cxx.h
@@ -29,16 +29,16 @@ enum HeapID : int32_t
 
 };
 
-void* operator new( size_t size );
-void* operator new[]( size_t size );
-void* operator new( size_t size, int32_t alignment );
-void* operator new[]( size_t size, int32_t alignment );
+void* operator new( std::size_t size );
+void* operator new[]( std::size_t size );
+void* operator new( std::size_t size, int32_t alignment );
+void* operator new[]( std::size_t size, int32_t alignment );
 void* operator new( std::size_t size, int32_t alignment, int32_t heapId );
 void* operator new[]( std::size_t size, int32_t alignment, int32_t heapId );
 void operator delete( void* ptr );
 void operator delete[]( void* ptr );
-void operator delete( void* ptr, size_t size );
-void operator delete[]( void* ptr, size_t size );
+void operator delete( void* ptr, std::size_t size );
+void operator delete[]( void* ptr, std::size_t size );
 void freeFromHeap( int32_t id, void* ptr );
 
 #endif     // LIBTP_CXX_H

--- a/include/cxx.h
+++ b/include/cxx.h
@@ -22,9 +22,9 @@ enum HeapID : int32_t
     HEAP_J2D,
 
 #ifndef PLATFORM_WII
-
     HEAP_HOST_IO,
-
+#else
+    HEAP_DYNAMIC_LINK,
 #endif
 
 };

--- a/include/cxx.h
+++ b/include/cxx.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <new>
+#include <cstdint>
+
+enum HeapID : int32_t
+{
+    HEAP_ASSERT = 0,
+    HEAP_DBPRINT,
+    HEAP_GAME,
+    HEAP_ZELDA,
+    HEAP_COMMAND,
+    HEAP_ARCHIVE,
+    HEAP_J2D,
+};
+
+void* operator new(size_t size);
+void* operator new[](size_t size);
+void* operator new(size_t size, int32_t alignment);
+void* operator new[](size_t size, int32_t alignment);
+void* operator new(std::size_t size, int32_t alignment, int32_t heapId);
+void* operator new[](std::size_t size, int32_t alignment, int32_t heapId);
+void operator delete(void* ptr);
+void operator delete[](void* ptr);
+void operator delete(void* ptr, size_t size);
+void operator delete[](void* ptr, size_t size);
+void freeFromHeap(int32_t id, void* ptr);

--- a/include/cxx.h
+++ b/include/cxx.h
@@ -1,13 +1,15 @@
 /**	@file cxx.h
  *	@brief Custom override of (de)allocation onto specific heaps.
  *
- *  @author Zephiles
+ *	@author Zephiles
+ *	@author kipcode66
  *	@bug No known bugs.
  */
-#pragma once
+#ifndef LIBTP_CXX_H
+#define LIBTP_CXX_H
 
-#include <new>
 #include <cstdint>
+#include <new>
 
 enum HeapID : int32_t
 {
@@ -18,16 +20,25 @@ enum HeapID : int32_t
     HEAP_COMMAND,
     HEAP_ARCHIVE,
     HEAP_J2D,
+
+#ifndef PLATFORM_WII
+
+    HEAP_HOST_IO,
+
+#endif
+
 };
 
-void* operator new(size_t size);
-void* operator new[](size_t size);
-void* operator new(size_t size, int32_t alignment);
-void* operator new[](size_t size, int32_t alignment);
-void* operator new(std::size_t size, int32_t alignment, int32_t heapId);
-void* operator new[](std::size_t size, int32_t alignment, int32_t heapId);
-void operator delete(void* ptr);
-void operator delete[](void* ptr);
-void operator delete(void* ptr, size_t size);
-void operator delete[](void* ptr, size_t size);
-void freeFromHeap(int32_t id, void* ptr);
+void* operator new( size_t size );
+void* operator new[]( size_t size );
+void* operator new( size_t size, int32_t alignment );
+void* operator new[]( size_t size, int32_t alignment );
+void* operator new( std::size_t size, int32_t alignment, int32_t heapId );
+void* operator new[]( std::size_t size, int32_t alignment, int32_t heapId );
+void operator delete( void* ptr );
+void operator delete[]( void* ptr );
+void operator delete( void* ptr, size_t size );
+void operator delete[]( void* ptr, size_t size );
+void freeFromHeap( int32_t id, void* ptr );
+
+#endif     // LIBTP_CXX_H

--- a/include/cxx.h
+++ b/include/cxx.h
@@ -1,3 +1,9 @@
+/**	@file cxx.h
+ *	@brief Custom override of (de)allocation onto specific heaps.
+ *
+ *  @author Zephiles
+ *	@bug No known bugs.
+ */
 #pragma once
 
 #include <new>

--- a/include/gc_wii/nand.h
+++ b/include/gc_wii/nand.h
@@ -4,6 +4,7 @@
  *	Refer to the dolphin OS Reference Manual for further information
  *
  *	@author kipcode66
+ *  @author Zephiles
  *	@bug No known bugs.
  */
 #ifndef GC_WII_NAND_H
@@ -17,6 +18,13 @@
 #define NAND_OPEN_READ 0x01
 #define NAND_OPEN_WRITE 0x02
 #define NAND_OPEN_RW ( NAND_OPEN_READ | NAND_OPEN_WRITE )
+
+#define NAND_PERM_OTHER_READ   0x01
+#define NAND_PERM_OTHER_WRITE  0x02
+#define NAND_PERM_GROUP_READ   0x04
+#define NAND_PERM_GROUP_WRITE  0x08
+#define NAND_PERM_OWNER_READ   0x10
+#define NAND_PERM_OWNER_WRITE  0x20
 
 #define NAND_RESULT_UNLOCKED 1
 #define NAND_RESULT_READY 0
@@ -42,21 +50,107 @@ namespace libtp::gc_wii::nand
     typedef struct NANDFileInfo
     {
         uint8_t unk[0x90];
-    } NANDFileInfo;
+    } __attribute__( ( __packed__ ) ) NANDFileInfo;
 
     extern "C"
     {
-        int32_t NANDCreate( const char* fileName, uint32_t unk2, int32_t unk3 );
-        int32_t NANDDelete( const char* fileName );
-        int32_t NANDOpen( const char* fileName, NANDFileInfo* fileInfo, uint32_t mode );
-        int32_t NANDSafeOpen( const char* fileName, NANDFileInfo* fileInfo, uint32_t mode, void* safeCopyBuf, uint32_t size );
-        int32_t NANDClose( NANDFileInfo* fileInfo );
-        int32_t NANDSafeClose( NANDFileInfo* fileInfo );
-        int32_t NANDRead( NANDFileInfo* fileInfo, void* dest, uint32_t length );
-        int32_t NANDWrite( NANDFileInfo* fileInfo, void* src, uint32_t length );
-        int32_t NANDSeek( NANDFileInfo* fileInfo, uint32_t offset, int32_t unk1 );
-
+        // Variables
+        /**
+         *  @brief No decent description at this time
+         */
         extern uint8_t l_safeCopyBuf[0x4000];
+
+        // Functions
+        /**
+         *  @brief Initializes NAND API control blocks. Must be called once before using any other NAND API functions.
+         */
+        void NANDInit( void );
+
+        /**
+         * @brief Creates a new file on the NAND memory file system.
+         * 
+         * @param fileName Path to the file
+         * @param permissions Permissions of the file
+         * @param attributes Unknown usage. Default to 0
+         * @return int32_t Error code of the execution
+         */
+        int32_t NANDCreate(const char *fileName, uint8_t permissions, int8_t attributes);
+        
+        /**
+         * @brief Deletes a file from the NAND memory file system.
+         * 
+         * @param fileName Path to the file
+         * @return int32_t Error code of the execution
+         */
+        int32_t NANDDelete(const char *fileName);
+
+        /**
+         * @brief Opens a file on the NAND memory file system.
+         * 
+         * @param fileName Path to the file
+         * @param fileInfo Pointer to file info to be used
+         * @param mode Open mode for the file (Read/Write/RW)
+         * @return int32_t Error code of the operation
+         */
+        int32_t NANDOpen(const char *fileName, NANDFileInfo *fileInfo, uint32_t mode);
+
+        /**
+         * @brief Safely opens a file on the NAND memory file system.
+         * 
+         * @param fileName Path to the file
+         * @param fileInfo Pointer to file info to be used
+         * @param mode Open mode for the file (Read/Write/RW)
+         * @param safeCopyBuf Buffer to use when interacting with the file
+         * @param size Size of the buffer
+         * @return int32_t Error code of the operation
+         */
+        int32_t NANDSafeOpen(const char *fileName, NANDFileInfo *fileInfo, uint32_t mode, void* safeCopyBuf, uint32_t size);
+
+        /**
+         * @brief Closes a file on the NAND memory file system.
+         * 
+         * @param fileInfo Pointer to file info to be closed
+         * @return int32_t Error code of the operation
+         */
+        int32_t NANDClose(NANDFileInfo *fileInfo);
+
+        /**
+         * @brief Safely closes a file on the NAND memory file system
+         * 
+         * @param fileInfo Pointer to file info to be closed
+         * @return int32_t Error code of the operation
+         */
+        int32_t NANDSafeClose(NANDFileInfo *fileInfo);
+
+        /**
+         * @brief Reads from a file synchronously.
+         * 
+         * @param fileInfo Pointer to the file info of the file to be read
+         * @param dest Buffer address (32 bytes aligned)
+         * @param length Number of bytes to be read (multiple of NAND_READ_SIZE)
+         * @return int32_t Number of bytes read from the file
+         */
+        int32_t NANDRead(NANDFileInfo *fileInfo, void *dest, uint32_t length);
+
+        /**
+         * @brief Writes data to a file synchronously.
+         * 
+         * @param fileInfo Pointer to the file info of the file to be written
+         * @param src buffer address (32 bytes aligned)
+         * @param length number of bytes to write. The length must be multiple of the card sector size
+         * @return int32_t Number of bytes written to the file
+         */
+        int32_t NANDWrite(NANDFileInfo *fileInfo, void *src, uint32_t length);
+
+        /**
+         * @brief Seeks to a given offset of a file.
+         * 
+         * @param fileInfo Pointer to the file info of the file to seek into
+         * @param offset File position to seek to
+         * @param unk1 Unknown (maybe the seek mode? from Start ?= 0). Default to 0
+         * @return int32_t 
+         */
+        int32_t NANDSeek(NANDFileInfo *fileInfo, uint32_t offset, int32_t unk1);
     }
 
 }     // namespace libtp::gc_wii::nand

--- a/include/gc_wii/nand.h
+++ b/include/gc_wii/nand.h
@@ -1,0 +1,64 @@
+/**	@file nand.h
+ *	@brief The NAND API provides file level access to the Wii's nand flash.
+ *
+ *	Refer to the dolphin OS Reference Manual for further information
+ *
+ *	@author kipcode66
+ *	@bug No known bugs.
+ */
+#ifndef GC_WII_NAND_H
+#define GC_WII_NAND_H
+
+#include <cstdint>
+
+#define NAND_FILENAME_MAX 32
+#define SECTOR_SIZE 0x200
+
+#define NAND_OPEN_READ 0x01
+#define NAND_OPEN_WRITE 0x02
+#define NAND_OPEN_RW ( NAND_OPEN_READ | NAND_OPEN_WRITE )
+
+#define NAND_RESULT_UNLOCKED 1
+#define NAND_RESULT_READY 0
+#define NAND_RESULT_BUSY -1
+#define NAND_RESULT_WRONGDEVICE -2
+#define NAND_RESULT_NOCARD -3
+#define NAND_RESULT_NOFILE -4
+#define NAND_RESULT_IOERROR -5
+#define NAND_RESULT_BROKEN -6
+#define NAND_RESULT_EXIST -7
+#define NAND_RESULT_NOENT -8
+#define NAND_RESULT_INSSPACE -9
+#define NAND_RESULT_NOPERM -10
+#define NAND_RESULT_LIMIT -11
+#define NAND_RESULT_NAMETOOLONG -12
+#define NAND_RESULT_ENCODING -13
+#define NAND_RESULT_FATAL_ERROR -128
+
+#define NAND_READ_SIZE 0x200
+
+namespace libtp::gc_wii::nand
+{
+    typedef struct NANDFileInfo
+    {
+        uint8_t unk[0x90];
+    } NANDFileInfo;
+
+    extern "C"
+    {
+        int32_t NANDCreate( const char* fileName, uint32_t unk2, int32_t unk3 );
+        int32_t NANDDelete( const char* fileName );
+        int32_t NANDOpen( const char* fileName, NANDFileInfo* fileInfo, uint32_t mode );
+        int32_t NANDSafeOpen( const char* fileName, NANDFileInfo* fileInfo, uint32_t mode, void* safeCopyBuf, uint32_t size );
+        int32_t NANDClose( NANDFileInfo* fileInfo );
+        int32_t NANDSafeClose( NANDFileInfo* fileInfo );
+        int32_t NANDRead( NANDFileInfo* fileInfo, void* dest, uint32_t length );
+        int32_t NANDWrite( NANDFileInfo* fileInfo, void* src, uint32_t length );
+        int32_t NANDSeek( NANDFileInfo* fileInfo, uint32_t offset, int32_t unk1 );
+
+        extern uint8_t l_safeCopyBuf[0x4000];
+    }
+
+}     // namespace libtp::gc_wii::nand
+
+#endif

--- a/include/gc_wii/nand.h
+++ b/include/gc_wii/nand.h
@@ -45,7 +45,7 @@ namespace libtp::gc_wii::nand
     extern "C"
     {
         // Variables
-        /** 
+        /**
          * @brief Static memory intended to be used with the Safe version of NANDOpen.
          */
         extern uint8_t l_safeCopyBuf[0x4000];
@@ -142,10 +142,10 @@ namespace libtp::gc_wii::nand
          *
          * @param fileInfo Pointer to the file info of the file to seek into
          * @param offset File position to seek to
-         * @param unk1 Base position to seek from (Start/Current/End)
+         * @param basePosition Base position to seek from (Start/Current/End)
          * @return int32_t The new position of the cursor, or an error code for the operation
          */
-        int32_t NANDSeek( NANDFileInfo* fileInfo, uint32_t offset, int32_t unk1 );
+        int32_t NANDSeek( NANDFileInfo* fileInfo, uint32_t offset, int32_t basePosition );
     }
 
 }     // namespace libtp::gc_wii::nand

--- a/include/gc_wii/nand.h
+++ b/include/gc_wii/nand.h
@@ -4,7 +4,7 @@
  *	Refer to the dolphin OS Reference Manual for further information
  *
  *	@author kipcode66
- *  @author Zephiles
+ *	@author Zephiles
  *	@bug No known bugs.
  */
 #ifndef GC_WII_NAND_H
@@ -12,145 +12,140 @@
 
 #include <cstdint>
 
-#define NAND_FILENAME_MAX 32
-#define SECTOR_SIZE 0x200
+// NAND_FILENAME_MAX does not include a null terminator
+#define NAND_FILENAME_MAX 12
 
 #define NAND_OPEN_READ 0x01
 #define NAND_OPEN_WRITE 0x02
 #define NAND_OPEN_RW ( NAND_OPEN_READ | NAND_OPEN_WRITE )
 
-#define NAND_PERM_OTHER_READ   0x01
-#define NAND_PERM_OTHER_WRITE  0x02
-#define NAND_PERM_GROUP_READ   0x04
-#define NAND_PERM_GROUP_WRITE  0x08
-#define NAND_PERM_OWNER_READ   0x10
-#define NAND_PERM_OWNER_WRITE  0x20
+#define NAND_PERM_OTHER_READ 0x01
+#define NAND_PERM_OTHER_WRITE 0x02
+#define NAND_PERM_GROUP_READ 0x04
+#define NAND_PERM_GROUP_WRITE 0x08
+#define NAND_PERM_OWNER_READ 0x10
+#define NAND_PERM_OWNER_WRITE 0x20
 
-#define NAND_RESULT_UNLOCKED 1
 #define NAND_RESULT_READY 0
-#define NAND_RESULT_BUSY -1
-#define NAND_RESULT_WRONGDEVICE -2
-#define NAND_RESULT_NOCARD -3
-#define NAND_RESULT_NOFILE -4
-#define NAND_RESULT_IOERROR -5
-#define NAND_RESULT_BROKEN -6
-#define NAND_RESULT_EXIST -7
-#define NAND_RESULT_NOENT -8
-#define NAND_RESULT_INSSPACE -9
-#define NAND_RESULT_NOPERM -10
-#define NAND_RESULT_LIMIT -11
-#define NAND_RESULT_NAMETOOLONG -12
-#define NAND_RESULT_ENCODING -13
-#define NAND_RESULT_FATAL_ERROR -128
+// TODO Add NAND_RESULT error codes
 
-#define NAND_READ_SIZE 0x200
+#define NAND_SEEK_START 0x0
+#define NAND_SEEK_CURRENT 0x1
+#define NAND_SEEK_END 0x2
+
+#define NAND_READ_SIZE 0x20
 
 namespace libtp::gc_wii::nand
 {
     typedef struct NANDFileInfo
     {
-        uint8_t unk[0x90];
+        uint8_t unk[0x8C];
     } __attribute__( ( __packed__ ) ) NANDFileInfo;
 
     extern "C"
     {
         // Variables
-        /**
-         *  @brief No decent description at this time
+        /** 
+         * @brief Static memory intended to be used with the Safe version of NANDOpen.
          */
         extern uint8_t l_safeCopyBuf[0x4000];
 
         // Functions
         /**
-         *  @brief Initializes NAND API control blocks. Must be called once before using any other NAND API functions.
+         * @brief Initializes NAND API control blocks. Must be called once before using any other NAND API functions.
+         * @return int32_t Error code of the execution
          */
-        void NANDInit( void );
+        int32_t NANDInit( void );
 
         /**
          * @brief Creates a new file on the NAND memory file system.
-         * 
+         *
          * @param fileName Path to the file
          * @param permissions Permissions of the file
          * @param attributes Unknown usage. Default to 0
          * @return int32_t Error code of the execution
          */
-        int32_t NANDCreate(const char *fileName, uint8_t permissions, int8_t attributes);
-        
+        int32_t NANDCreate( const char* fileName, uint8_t permissions, int8_t attributes );
+
         /**
          * @brief Deletes a file from the NAND memory file system.
-         * 
+         *
          * @param fileName Path to the file
          * @return int32_t Error code of the execution
          */
-        int32_t NANDDelete(const char *fileName);
+        int32_t NANDDelete( const char* fileName );
 
         /**
          * @brief Opens a file on the NAND memory file system.
-         * 
+         *
          * @param fileName Path to the file
          * @param fileInfo Pointer to file info to be used
-         * @param mode Open mode for the file (Read/Write/RW)
+         * @param access_type Access type for the file (Read/Write/RW)
          * @return int32_t Error code of the operation
          */
-        int32_t NANDOpen(const char *fileName, NANDFileInfo *fileInfo, uint32_t mode);
+        int32_t NANDOpen( const char* fileName, NANDFileInfo* fileInfo, uint8_t access_type );
 
         /**
          * @brief Safely opens a file on the NAND memory file system.
-         * 
+         *
          * @param fileName Path to the file
          * @param fileInfo Pointer to file info to be used
-         * @param mode Open mode for the file (Read/Write/RW)
+         * @param access_type Access type for the file (Read/Write/RW)
          * @param safeCopyBuf Buffer to use when interacting with the file
          * @param size Size of the buffer
          * @return int32_t Error code of the operation
          */
-        int32_t NANDSafeOpen(const char *fileName, NANDFileInfo *fileInfo, uint32_t mode, void* safeCopyBuf, uint32_t size);
+        int32_t NANDSafeOpen( const char* fileName,
+                              NANDFileInfo* fileInfo,
+                              uint8_t access_type,
+                              void* safeCopyBuf,
+                              uint32_t size );
 
         /**
          * @brief Closes a file on the NAND memory file system.
-         * 
+         *
          * @param fileInfo Pointer to file info to be closed
          * @return int32_t Error code of the operation
          */
-        int32_t NANDClose(NANDFileInfo *fileInfo);
+        int32_t NANDClose( NANDFileInfo* fileInfo );
 
         /**
          * @brief Safely closes a file on the NAND memory file system
-         * 
+         *
          * @param fileInfo Pointer to file info to be closed
          * @return int32_t Error code of the operation
          */
-        int32_t NANDSafeClose(NANDFileInfo *fileInfo);
+        int32_t NANDSafeClose( NANDFileInfo* fileInfo );
 
         /**
          * @brief Reads from a file synchronously.
-         * 
+         *
          * @param fileInfo Pointer to the file info of the file to be read
          * @param dest Buffer address (32 bytes aligned)
          * @param length Number of bytes to be read (multiple of NAND_READ_SIZE)
-         * @return int32_t Number of bytes read from the file
+         * @return int32_t Actual number of bytes read from the file (not rounded to 32), or an error code for the operation
          */
-        int32_t NANDRead(NANDFileInfo *fileInfo, void *dest, uint32_t length);
+        int32_t NANDRead( NANDFileInfo* fileInfo, void* dest, uint32_t length );
 
         /**
          * @brief Writes data to a file synchronously.
-         * 
+         *
          * @param fileInfo Pointer to the file info of the file to be written
          * @param src buffer address (32 bytes aligned)
-         * @param length number of bytes to write. The length must be multiple of the card sector size
+         * @param length Number of bytes to be written (multiple of NAND_READ_SIZE)
          * @return int32_t Number of bytes written to the file
          */
-        int32_t NANDWrite(NANDFileInfo *fileInfo, void *src, uint32_t length);
+        int32_t NANDWrite( NANDFileInfo* fileInfo, const void* src, uint32_t length );
 
         /**
-         * @brief Seeks to a given offset of a file.
-         * 
+         * @brief Seeks the read/write cursor to a given offset of a file.
+         *
          * @param fileInfo Pointer to the file info of the file to seek into
          * @param offset File position to seek to
-         * @param unk1 Unknown (maybe the seek mode? from Start ?= 0). Default to 0
-         * @return int32_t 
+         * @param unk1 Base position to seek from (Start/Current/End)
+         * @return int32_t The new position of the cursor, or an error code for the operation
          */
-        int32_t NANDSeek(NANDFileInfo *fileInfo, uint32_t offset, int32_t unk1);
+        int32_t NANDSeek( NANDFileInfo* fileInfo, uint32_t offset, int32_t unk1 );
     }
 
 }     // namespace libtp::gc_wii::nand

--- a/include/gc_wii/nand.h
+++ b/include/gc_wii/nand.h
@@ -145,7 +145,7 @@ namespace libtp::gc_wii::nand
          * @param basePosition Base position to seek from (Start/Current/End)
          * @return int32_t The new position of the cursor, or an error code for the operation
          */
-        int32_t NANDSeek( NANDFileInfo* fileInfo, uint32_t offset, int32_t basePosition );
+        int32_t NANDSeek( NANDFileInfo* fileInfo, int32_t offset, int32_t basePosition );
     }
 
 }     // namespace libtp::gc_wii::nand

--- a/include/patch.h
+++ b/include/patch.h
@@ -10,6 +10,7 @@
 #include <cstdint>
 
 #include "memory.h"
+#include "cxx.h"
 
 namespace libtp::patch
 {
@@ -22,7 +23,11 @@ namespace libtp::patch
     {
         uint32_t* instructions = reinterpret_cast<uint32_t*>( function );
 
+#ifdef PLATFORM_WII
+        uint32_t* trampoline = new (0x4, HEAP_ZELDA) uint32_t[2];
+#else
         uint32_t* trampoline = new uint32_t[2];
+#endif
 
         // Original instruction
         trampoline[0] = instructions[0];

--- a/include/tools.h
+++ b/include/tools.h
@@ -6,7 +6,9 @@
  *  @todo At some point we might want to seperate functions into different namespaces
  * i.e. tools::array, tools::hashing, etc.; for now there aren't enough functions for this to make sense
  */
-#pragma once
+#ifndef LIBTP_TOOLS_H
+#define LIBTP_TOOLS_H
+
 #include <cstdint>
 
 #include "tp/dzx.h"
@@ -41,6 +43,8 @@ namespace libtp::tools
      */
     void SpawnActor( uint8_t roomID, tp::dzx::ACTR& actor );
 
+#ifndef PLATFORM_WII
+
     /**
      *  @brief Reads GCI data from offset to offset + length into buffer
      *
@@ -54,7 +58,8 @@ namespace libtp::tools
      */
     int32_t ReadGCI( int32_t chan, const char* fileName, int32_t length, int32_t offset, void* buffer );
 
-#ifdef PLATFORM_WII
+#else     // PLATFORM_WII
+
     /**
      *  @brief Reads NAND data from offset to offset + length into buffer
      *
@@ -66,7 +71,8 @@ namespace libtp::tools
      *  @return One of the NAND_RESULT Constants (NAND_RESULT_READY, ...)
      */
     int32_t ReadNAND( const char* fileName, int32_t length, int32_t offset, void* buffer );
-#endif  // PLATFORM_WII
+
+#endif     // PLATFORM_WII
 
     /**
      * @brief Generates a random number based on a seed and a maximum number
@@ -76,3 +82,5 @@ namespace libtp::tools
      */
     uint32_t getRandom( uint64_t* seed, uint32_t max );
 }     // namespace libtp::tools
+
+#endif     // LIBTP_TOOLS_H

--- a/include/tools.h
+++ b/include/tools.h
@@ -54,6 +54,20 @@ namespace libtp::tools
      */
     int32_t ReadGCI( int32_t chan, const char* fileName, int32_t length, int32_t offset, void* buffer );
 
+#ifdef PLATFORM_WII
+    /**
+     *  @brief Reads NAND data from offset to offset + length into buffer
+     *
+     *  @param fileName NAND Filename to load
+     *  @param length Maximum length to read
+     *  @param offset NAND fileOffset to read
+     *  @param[out] buffer Buffer to save the data
+     *
+     *  @return One of the NAND_RESULT Constants (NAND_RESULT_READY, ...)
+     */
+    int32_t ReadNAND( const char* fileName, int32_t length, int32_t offset, void* buffer );
+#endif  // PLATFORM_WII
+
     /**
      * @brief Generates a random number based on a seed and a maximum number
      *

--- a/include/tp/dynamic_link.h
+++ b/include/tp/dynamic_link.h
@@ -29,5 +29,13 @@ namespace libtp::tp::dynamic_link
         bool do_link( DynamicModuleControl* dmc );
         bool do_unlink( DynamicModuleControl* dmc );
     }
+
+    namespace DynamicModuleControlBase
+    {
+        extern "C"
+        {
+            extern void* m_heap;
+        }
+    }     // namespace DynamicModuleControlBase
 }     // namespace libtp::tp::dynamic_link
 #endif

--- a/include/tp/m_do_ext.h
+++ b/include/tp/m_do_ext.h
@@ -13,16 +13,14 @@ namespace libtp::tp::m_Do_ext
     {
         extern void* AssertHeap;
         extern void* DbPrintHeap;
-        extern void* gameHeap;     // Dynamic link heap
+        extern void* gameHeap;
         extern void* zeldaHeap;
         extern void* commandHeap;
         extern void* archiveHeap;     // Archive heap pointer
         extern void* j2dHeap;
 
 #ifndef PLATFORM_WII
-
         extern void* HostIOHeap;
-
 #endif     // PLATFORM_WII
     }
 }     // namespace libtp::tp::m_Do_ext

--- a/include/tp/m_do_ext.h
+++ b/include/tp/m_do_ext.h
@@ -11,7 +11,13 @@ namespace libtp::tp::m_Do_ext
 {
     extern "C"
     {
+        extern void* AssertHeap;
+        extern void* DbPrintHeap;
+        extern void* gameHeap;        // Dynamic link heap
+        extern void* zeldaHeap;
+        extern void* commandHeap;
         extern void* archiveHeap;     // Archive heap pointer
+        extern void* j2dHeap;
     }
 }     // namespace libtp::tp::m_Do_ext
 #endif

--- a/include/tp/m_do_ext.h
+++ b/include/tp/m_do_ext.h
@@ -13,11 +13,17 @@ namespace libtp::tp::m_Do_ext
     {
         extern void* AssertHeap;
         extern void* DbPrintHeap;
-        extern void* gameHeap;        // Dynamic link heap
+        extern void* gameHeap;     // Dynamic link heap
         extern void* zeldaHeap;
         extern void* commandHeap;
         extern void* archiveHeap;     // Archive heap pointer
         extern void* j2dHeap;
+
+#ifndef PLATFORM_WII
+
+        extern void* HostIOHeap;
+
+#endif     // PLATFORM_WII
     }
 }     // namespace libtp::tp::m_Do_ext
 #endif

--- a/include/tp/m_do_printf.h
+++ b/include/tp/m_do_printf.h
@@ -7,11 +7,13 @@
 #ifndef TP_M_DO_EXT_H
 #define TP_M_DO_EXT_H
 
+#include <cstdarg>
+
 namespace libtp::tp::m_Do_printf
 {
     extern "C"
     {
-        void OSReport(const char *string, ...);
+        void OSReport( const char* string, ... );
     }
 }     // namespace libtp::tp::m_Do_printf
 

--- a/include/tp/m_do_printf.h
+++ b/include/tp/m_do_printf.h
@@ -1,0 +1,18 @@
+/**	@file m_do_printf.h
+ *	@brief Holds symbols of the m_do_printf field
+ *
+ *	@author kipcode66
+ *	@bug No known bugs.
+ */
+#ifndef TP_M_DO_EXT_H
+#define TP_M_DO_EXT_H
+
+namespace libtp::tp::m_Do_printf
+{
+    extern "C"
+    {
+        void OSReport(const char *string, ...);
+    }
+}     // namespace libtp::tp::m_Do_printf
+
+#endif

--- a/include/tp/m_re_controller_pad.h
+++ b/include/tp/m_re_controller_pad.h
@@ -1,0 +1,88 @@
+/**	@file m_re_controller_pad.h
+ *	@brief Holds symbols related to the revolution (Wii) controller
+ *
+ *	@author kipcode66
+ *	@bug No known bugs.
+ */
+#ifndef TP_M_RE_CONTROLLER_PAD_H
+#define TP_M_RE_CONTROLLER_PAD_H
+
+#include <dolphin/mtx/vec.h>
+
+#include <cstdint>
+
+struct Vec2
+{
+    float x, y;
+};
+static_assert( sizeof( Vec2 ) == 0x8 );
+
+namespace libtp::tp::m_re_controller_pad
+{
+    /**
+     *  @brief Controller inputs
+     */
+    enum ReCPadInputs : uint16_t
+    {
+        Button_DPad_Left = 0x0001,
+        Button_DPad_Right = 0x0002,
+        Button_DPad_Down = 0x0004,
+        Button_DPad_Up = 0x0008,
+        Button_Plus = 0x0010,
+        Button_Two = 0x0100,
+        Button_One = 0x0200,
+        Button_B = 0x0400,
+        Button_A = 0x0800,
+        Button_Minus = 0x1000,
+        Button_Z = 0x2000,
+        Button_C = 0x4000,
+        Button_Home = 0x8000,
+    };
+
+    struct Pointer
+    {
+        Vec2 pos;              // 8044BB84
+        uint8_t _p1[0x20];     // 8044BB8C
+        float scr_dist;        // 8044BBAC // Relative distance of the remote to the sensor bar
+    };
+    static_assert( sizeof( Pointer ) == 0x2C );
+
+    struct ReCPad
+    {
+        uint8_t _unk1[4];               // 8044BB60
+        uint8_t _p1[2];                 // 8044BB64
+        uint16_t held;                  // 8044BB66
+        uint8_t _p2[2];                 // 8044BB68
+        uint16_t down;                  // 8044BB6A
+        uint8_t _p3[2];                 // 8044BB6C
+        uint16_t up;                    // 8044BB6E
+        Vec wiimote_acc;                // 8044BB70
+        float wiimote_acc_strength;     // 8044BB7C
+        float wiimote_shake;            // 8044BB80 // Unsure of the real meaning of this, needs more verification
+        Pointer pointer;                // 8044BB84
+        uint8_t _p4[8];                 // 8044BBB0
+        float horizontal;               // 8044BBB8 // Goes from 0.0 to 1.0, shows how much the remote is horizontal
+        float
+            vertical;     // 8044BBBC // Goes from -1.0 to 1.0, shows how much the remote is vertical (up is 1.0, down is -1.0)
+        uint32_t ext_type;               // 8044BBC0
+        Vec2 stick;                      // 8044BBC4
+        Vec nunchuck_acc;                // 8044BBCC
+        float nunchuck_acc_strength;     // 8044BBD8
+        float nunchuck_shake;            // 8044BBDC // Unsure of the real meaning of this, needs more verification
+        uint8_t _p5[0x8];                // 8044BBE0
+        uint8_t n_points;                // 8044BBE8 // Number of IR points seen by the remote
+        uint8_t _p6[0x1CE7];             // 8044BBE9
+        float stick_amplitude;           // 8044D8D0
+        uint8_t _p7[0x5AAC];             // 8044D8D4
+    };
+    static_assert( sizeof( ReCPad ) == 0x7820 );
+
+    extern "C"
+    {
+        namespace mReCPd
+        {
+            extern ReCPad m_pad;
+        }
+    }
+}     // namespace libtp::tp::m_re_controller_pad
+#endif

--- a/source/cxx.cpp
+++ b/source/cxx.cpp
@@ -4,17 +4,17 @@
  *  @author Zephiles
  *	@bug No known bugs.
  */
+#include "cxx.h"
+
 #include <cstdint>
 #include <cstring>
-#include "cxx.h"
 
 #include "tp/JKRExpHeap.h"
 #include "tp/m_do_ext.h"
 
-void* getHeapPtr(int32_t id)
+void* getHeapPtr( int32_t id )
 {
-    static void** heapPtrArray[] = 
-    {
+    static void** heapPtrArray[] = {
         &libtp::tp::m_Do_ext::AssertHeap,
         &libtp::tp::m_Do_ext::DbPrintHeap,
         &libtp::tp::m_Do_ext::gameHeap,
@@ -22,11 +22,17 @@ void* getHeapPtr(int32_t id)
         &libtp::tp::m_Do_ext::commandHeap,
         &libtp::tp::m_Do_ext::archiveHeap,
         &libtp::tp::m_Do_ext::j2dHeap,
+
+#ifndef PLATFORM_WII
+
+        &libtp::tp::m_Do_ext::HostIOHeap,
+
+#endif     // PLATFORM_WII
     };
 
     // Make sure the id is valid
-    constexpr uint32_t heapPtrArraySize = sizeof(heapPtrArray) / sizeof(heapPtrArray[0]);
-    if ((id < 0) || (static_cast<uint32_t>(id) >= heapPtrArraySize))
+    constexpr uint32_t heapPtrArraySize = sizeof( heapPtrArray ) / sizeof( heapPtrArray[0] );
+    if ( ( id < 0 ) || ( static_cast<uint32_t>( id ) >= heapPtrArraySize ) )
     {
         // The id is invalid, so use the archive heap by default
         id = HEAP_ARCHIVE;
@@ -80,23 +86,23 @@ void operator delete[]( void* ptr, std::size_t size )
     return libtp::tp::jkr_exp_heap::do_free_JKRExpHeap( archiveHeapPtr, ptr );
 }
 
-void* operator new(size_t size, int32_t alignment, int32_t id)
+void* operator new( size_t size, int32_t alignment, int32_t id )
 {
-    void* heapPtr = getHeapPtr(id);
-    void* newPtr = libtp::tp::jkr_exp_heap::do_alloc_JKRExpHeap(heapPtr, size, alignment);
-    return memset(newPtr, 0, size);
+    void* heapPtr = getHeapPtr( id );
+    void* newPtr = libtp::tp::jkr_exp_heap::do_alloc_JKRExpHeap( heapPtr, size, alignment );
+    return memset( newPtr, 0, size );
 }
 
-void* operator new[](size_t size, int32_t alignment, int32_t id)
+void* operator new[]( size_t size, int32_t alignment, int32_t id )
 {
-    void* heapPtr = getHeapPtr(id);
-    void* newPtr = libtp::tp::jkr_exp_heap::do_alloc_JKRExpHeap(heapPtr, size, alignment);
-    return memset(newPtr, 0, size);
+    void* heapPtr = getHeapPtr( id );
+    void* newPtr = libtp::tp::jkr_exp_heap::do_alloc_JKRExpHeap( heapPtr, size, alignment );
+    return memset( newPtr, 0, size );
 }
 
 // Cannot used overloaded delete operator, so must use a generic function
-void freeFromHeap(int32_t id, void* ptr)
+void freeFromHeap( int32_t id, void* ptr )
 {
-    void* heapPtr = getHeapPtr(id);
-    return libtp::tp::jkr_exp_heap::do_free_JKRExpHeap(heapPtr, ptr);
+    void* heapPtr = getHeapPtr( id );
+    return libtp::tp::jkr_exp_heap::do_free_JKRExpHeap( heapPtr, ptr );
 }

--- a/source/cxx.cpp
+++ b/source/cxx.cpp
@@ -1,3 +1,9 @@
+/**	@file cxx.h
+ *	@brief Custom override of (de)allocation onto specific heaps.
+ *
+ *  @author Zephiles
+ *	@bug No known bugs.
+ */
 #include <cstdint>
 #include <cstring>
 #include "cxx.h"

--- a/source/cxx.cpp
+++ b/source/cxx.cpp
@@ -10,6 +10,7 @@
 #include <cstring>
 
 #include "tp/JKRExpHeap.h"
+#include "tp/dynamic_link.h"
 #include "tp/m_do_ext.h"
 
 void* getHeapPtr( int32_t id )
@@ -24,10 +25,11 @@ void* getHeapPtr( int32_t id )
         &libtp::tp::m_Do_ext::j2dHeap,
 
 #ifndef PLATFORM_WII
-
         &libtp::tp::m_Do_ext::HostIOHeap,
-
+#else
+        &libtp::tp::dynamic_link::DynamicModuleControlBase::m_heap,
 #endif     // PLATFORM_WII
+
     };
 
     // Make sure the id is valid

--- a/source/cxx.cpp
+++ b/source/cxx.cpp
@@ -1,8 +1,33 @@
 #include <cstdint>
 #include <cstring>
+#include "cxx.h"
 
 #include "tp/JKRExpHeap.h"
 #include "tp/m_do_ext.h"
+
+void* getHeapPtr(int32_t id)
+{
+    static void** heapPtrArray[] = 
+    {
+        &libtp::tp::m_Do_ext::AssertHeap,
+        &libtp::tp::m_Do_ext::DbPrintHeap,
+        &libtp::tp::m_Do_ext::gameHeap,
+        &libtp::tp::m_Do_ext::zeldaHeap,
+        &libtp::tp::m_Do_ext::commandHeap,
+        &libtp::tp::m_Do_ext::archiveHeap,
+        &libtp::tp::m_Do_ext::j2dHeap,
+    };
+
+    // Make sure the id is valid
+    constexpr uint32_t heapPtrArraySize = sizeof(heapPtrArray) / sizeof(heapPtrArray[0]);
+    if ((id < 0) || (static_cast<uint32_t>(id) >= heapPtrArraySize))
+    {
+        // The id is invalid, so use the archive heap by default
+        id = HEAP_ARCHIVE;
+    }
+
+    return *heapPtrArray[id];
+}
 
 void* operator new( std::size_t size )
 {
@@ -47,4 +72,25 @@ void operator delete[]( void* ptr, std::size_t size )
 {
     void* archiveHeapPtr = libtp::tp::m_Do_ext::archiveHeap;
     return libtp::tp::jkr_exp_heap::do_free_JKRExpHeap( archiveHeapPtr, ptr );
+}
+
+void* operator new(size_t size, int32_t alignment, int32_t id)
+{
+    void* heapPtr = getHeapPtr(id);
+    void* newPtr = libtp::tp::jkr_exp_heap::do_alloc_JKRExpHeap(heapPtr, size, alignment);
+    return memset(newPtr, 0, size);
+}
+
+void* operator new[](size_t size, int32_t alignment, int32_t id)
+{
+    void* heapPtr = getHeapPtr(id);
+    void* newPtr = libtp::tp::jkr_exp_heap::do_alloc_JKRExpHeap(heapPtr, size, alignment);
+    return memset(newPtr, 0, size);
+}
+
+// Cannot used overloaded delete operator, so must use a generic function
+void freeFromHeap(int32_t id, void* ptr)
+{
+    void* heapPtr = getHeapPtr(id);
+    return libtp::tp::jkr_exp_heap::do_free_JKRExpHeap(heapPtr, ptr);
 }

--- a/source/display/console.cpp
+++ b/source/display/console.cpp
@@ -106,8 +106,9 @@ namespace libtp::display
 
     Console& operator<<( Console& console, char chr )
     {
-        char buf[1];
+        char buf[2];
         buf[0] = chr;
+        buf[1] = 0;
         console.parse( buf );
         return console;
     }

--- a/source/tools.cpp
+++ b/source/tools.cpp
@@ -6,14 +6,10 @@
 #include <cstring>
 
 #ifndef PLATFORM_WII
-
 #include "gc_wii/card.h"
-
 #else
-
 #include "cxx.h"
 #include "gc_wii/nand.h"
-
 #endif
 
 #include "display/console.h"

--- a/source/tools.cpp
+++ b/source/tools.cpp
@@ -174,7 +174,7 @@ namespace libtp::tools
         if ( result == NAND_RESULT_READY )
         {
             // result = storage_read( &fileInfo, data, adjustedLength, adjustedOffset, NAND_OPEN_READ );
-            result = NANDSeek( &fileInfo, adjustedOffset, 0 );
+            result = NANDSeek( &fileInfo, adjustedOffset, NAND_SEEK_START );
             if ( result == NAND_RESULT_READY )
             {
                 int32_t r = NANDRead( &fileInfo, data, adjustedLength );

--- a/source/tools.cpp
+++ b/source/tools.cpp
@@ -116,7 +116,8 @@ namespace libtp::tools
             result = NANDSeek( &fileInfo, adjustedOffset, 0 );
             if ( result == NAND_RESULT_READY )
             {
-                NANDRead( &fileInfo, data, adjustedLength );
+                int32_t r = NANDRead( &fileInfo, data, adjustedLength );
+                result = (r > 1) ? NAND_RESULT_READY : r;
             }
             NANDClose( &fileInfo );
 

--- a/source/tools.cpp
+++ b/source/tools.cpp
@@ -167,7 +167,7 @@ namespace libtp::tools
         int32_t adjustedLength = ( 1 + ( ( offset - adjustedOffset + length - 1 ) / NAND_READ_SIZE ) ) * NAND_READ_SIZE;
 
         // Buffer might not be adjusted to the new length so create a temporary data buffer
-        uint8_t* data = new ( 0x20 ) uint8_t[adjustedLength];
+        uint8_t* data = new uint8_t[adjustedLength];
 
         memset( buffer, 0, length );
         memset( data, 0, adjustedLength );

--- a/source/tools.cpp
+++ b/source/tools.cpp
@@ -141,7 +141,7 @@ namespace libtp::tools
     }
 
 #ifdef PLATFORM_WII
-    int32_t ReadNAND( int32_t chan, const char* fileName, int32_t length, int32_t offset, void* buffer )
+    int32_t ReadNAND( const char* fileName, int32_t length, int32_t offset, void* buffer )
     {
         using namespace libtp::gc_wii::nand;
 


### PR DESCRIPTION
This PR adds NAND functionnality, Wii remote controller inputs, and a minor fix for the console display.

This is using some code from Zephiles (for allocation related things). They are identified in the file headers.