### PR TITLE
Adding Wii US 1.2 and Wii JP stuff to d_meter

### DIFF
--- a/include/tp/d_meter2.h
+++ b/include/tp/d_meter2.h
@@ -26,7 +26,7 @@ namespace libtp::tp::d_meter2
         /* 0x118 */ void* field_0x118; // dDlst_base_c*
         /* 0x11C */ void* field_0x11c;
         /* 0x120 */ void* mpMap;       // dMeterMap_c*
-        /* 0x124 */ uint32_t field_0x124;
+        /* 0x124 */ uint32_t mStatus;
         /* 0x128 */ int32_t field_0x128;
         /* 0x12C */ int32_t field_0x12c;
         /* 0x130 */ float field_0x130;
@@ -45,69 +45,138 @@ namespace libtp::tp::d_meter2
         /* 0x18C */ float field_0x18c;
         /* 0x190 */ int16_t field_0x190;
         /* 0x192 */ int16_t mNowLifeGauge;
-        /* 0x194 */ int16_t field_0x194;
-        /* 0x196 */ int16_t field_0x196;
-        /* 0x198 */ int16_t field_0x198;
+#if defined(TP_WUS2) || defined(TP_WJP)
+        /* 0x194 */ uint8_t unk0[0xC]; //heart UI related maybe?
+        /* 0x1A0 */ int16_t mMaxLife;
+        /* 0x1A2 */ int16_t mNowMagic;
+        /* 0x1A4 */ int16_t mMaxMagic;
+        /* 0x1A6 */ int16_t field_0x19a;
+        /* 0x1A8 */ int32_t mNowOil;
+        /* 0x1AC */ int32_t mMaxOil;
+        /* 0x1B0 */ int32_t mNowOxygen;
+        /* 0x1B4 */ int32_t mMaxOxygen;
+#else
+        /* 0x194 */ int16_t mMaxLife;
+        /* 0x196 */ int16_t mNowMagic;
+        /* 0x198 */ int16_t mMaxMagic;
         /* 0x19A */ int16_t field_0x19a;
         /* 0x19C */ int32_t mNowOil;
         /* 0x1A0 */ int32_t mMaxOil;
-        /* 0x1A4 */ int32_t field_0x1a4;
-        /* 0x1A8 */ int32_t field_0x1a8;
+        /* 0x1A4 */ int32_t mNowOxygen;
+        /* 0x1A8 */ int32_t mMaxOxygen;
         /* 0x1AC */ int32_t field_0x1ac;
-        /* 0x1B0 */ uint16_t field_0x1b0;
-        /* 0x1B2 */ uint16_t field_0x1b2;
+        /* 0x1B0 */ uint16_t mRupeeNum;
+        /* 0x1B2 */ uint16_t mKeyNum;
         /* 0x1B4 */ uint16_t field_0x1b4;
         /* 0x1B6 */ uint16_t mSubContentsStringType;
+#endif
         /* 0x1B8 */ uint16_t field_0x1b8[5];
-        /* 0x1C2 */ uint8_t field_0x1c2;
-        /* 0x1C3 */ uint8_t field_0x1c3;
-        /* 0x1C4 */ uint8_t field_0x1c4;
-        /* 0x1C5 */ uint8_t field_0x1c5;
+        /* 0x1C2 */ uint8_t mLightDropNum;
+        /* 0x1C3 */ uint8_t mNeedLightDropNum;
+        /* 0x1C4 */ uint8_t mDoStatus;
+        /* 0x1C5 */ uint8_t mAStatus;
         /* 0x1C6 */ uint8_t field_0x1c6;
-        /* 0x1C7 */ uint8_t field_0x1c7;
-        /* 0x1C8 */ uint8_t field_0x1c8;
-        /* 0x1C9 */ uint8_t field_0x1c9;
-        /* 0x1CA */ uint8_t field_0x1ca;
-        /* 0x1CB */ uint8_t field_0x1cb;
-        /* 0x1CC */ uint8_t field_0x1cc;
-        /* 0x1CD */ uint8_t field_0x1cd;
-        /* 0x1CE */ uint8_t field_0x1ce;
-        /* 0x1CF */ uint8_t field_0x1cf;
-        /* 0x1D0 */ uint8_t field_0x1d0;
-        /* 0x1D1 */ uint8_t field_0x1d1;
-        /* 0x1D2 */ uint8_t field_0x1d2[4];
+        /* 0x1C7 */ uint8_t mCollectSmell;
+        /* 0x1C8 */ uint8_t mRStatus;
+        /* 0x1C9 */ uint8_t mZStatus;
+        /* 0x1CA */ uint8_t m3DStatus;
+        /* 0x1CB */ uint8_t mCStickStatus;
+        /* 0x1CC */ uint8_t mSButtonStatus;
+        /* 0x1CD */ uint8_t mNunStatus;
+        /* 0x1CE */ uint8_t mRemoConStatus;
+        /* 0x1CF */ uint8_t mNunZStatus;
+        /* 0x1D0 */ uint8_t mNunCStatus;
+        /* 0x1D1 */ uint8_t mBottleStatus;
+        /* 0x1D2 */ uint8_t mItemStatus[4];
         /* 0x1D6 */ uint8_t field_0x1d6[2];
         /* 0x1D8 */ uint8_t field_0x1d8[2];
-        /* 0x1DA */ uint8_t field_0x1da;
-        /* 0x1DB */ uint8_t field_0x1db;
-        /* 0x1DC */ uint8_t field_0x1dc;
-        /* 0x1DD */ uint8_t field_0x1dd;
-        /* 0x1DE */ uint8_t field_0x1de;
-        /* 0x1DF */ uint8_t field_0x1df;
-        /* 0x1E0 */ uint8_t field_0x1e0;
+#if defined(TP_WUS2) || defined(TP_WJP)
+        /* 0x1DA */ uint8_t unk1;
+        /* 0x1DB */ uint8_t unk11111;
+#else
+        /* 0x1DA */ uint8_t mArrowNum;
+        /* 0x1DB */ uint8_t mPachinkoNum;
+#endif
+        /* 0x1DC */ uint8_t mDoSetFlag;
+        /* 0x1DD */ uint8_t mASetFlag;
+        /* 0x1DE */ uint8_t mRSetFlag;
+        /* 0x1DF */ uint8_t mXSetFlag;
+        /* 0x1E0 */ uint8_t mYSetFlag;
         /* 0x1E1 */ uint8_t field_0x1e1;
-        /* 0x1E2 */ uint8_t field_0x1e2;
+        /* 0x1E2 */ uint8_t mEquipSword;
         /* 0x1E3 */ uint8_t field_0x1e3;
         /* 0x1E4 */ uint8_t field_0x1e4;
-        /* 0x1E5 */ uint8_t mSubContents;
+        /* 0x1E5 */ uint8_t mSubContentType;
         /* 0x1E6 */ uint8_t field_0x1e6;
         /* 0x1E7 */ uint8_t field_0x1e7;
         /* 0x1E8 */ uint8_t field_0x1e8;
         /* 0x1E9 */ uint8_t field_0x1e9;
-        /* 0x1EA */ uint8_t field_0x1ea;
-        /* 0x1EB */ uint8_t field_0x1eb;
+        /* 0x1EA */ uint8_t mRupeeSound;
+#if defined(TP_WUS2) || defined(TP_WJP)
+        /* 0x1EB */ uint8_t unk2;
+#else
+        /* 0x1EB */ uint8_t mArrowSound;
+#endif
         /* 0x1EC */ uint8_t field_0x1ec;
         /* 0x1ED */ uint8_t field_0x1ed;
-        /* 0x1EE */ uint8_t field_0x1ee;
-        /* 0x1EF */ uint8_t field_0x1ef[4];
-        /* 0x1F3 */ uint8_t field_0x1f3[3];
-        /* 0x1F6 */ uint8_t field_0x1f6[3];
-        /* 0x1F9 */ uint8_t field_0x1f9[4];
-        /* 0x1FD */ uint8_t field_0x1fd;
-        /* 0x1FE */ uint8_t field_0x1fe;
-        /* 0x1FF */ uint8_t field_0x1ff;
-        /* 0x200 */ uint8_t field_0x200;
-        /* 0x201 */ uint8_t field_0x201;
+        /* 0x1EE */ uint8_t mLifeCountType;
+#if defined(TP_WUS2) || defined(TP_WJP)
+        /* 0x1EF */ uint8_t mArrowNum;
+        /* 0x1F0 */ uint8_t mPachinkoNum;
+        /* 0x1F1 */ uint8_t padding_0x1F1[12];
+#else
+        /* 0x1EF */ uint8_t mBottleNum[4];
+        /* 0x1F3 */ uint8_t mBombNum[3];
+        /* 0x1F6 */ uint8_t mBombMax[3];
+        /* 0x1F9 */ uint8_t mItemMaxNum[4];
+#endif
+        /* 0x1FD */ uint8_t field_0x1fd[3];
+#if defined(TP_WUS2) || defined(TP_WJP)
+        /* 0x200 */ uint8_t field_0x200[2];
+        /* 0x202 */ uint8_t mArrowSound;
+#else
+        /* 0x200 */ uint8_t field_0x200[3];
+#endif
+        /* 0x203 */ uint8_t padding_0x203;
+        /* 0x204 */ float mLifeGuagePosX;
+#if defined(TP_WUS2) || defined(TP_WJP)
+        /* 0x208 */ uint8_t padding_0x208[2];
+        /* 0x20A */ uint8_t mBombNum[3];
+        /* 0x20D */ uint8_t mBombMax[3];
+        /* 0x210 */ uint8_t unk3[2];
+        /* 0x212 */ uint8_t mItemMaxNum[4];
+        /* 0x216 */ uint8_t unk4[2];
+        /* 0x218 */ uint8_t field_0x218[0x244 - 0x218];
+        /* 0x244 */ float mLanternMeterScale;
+        /* 0x248 */ float mLanternMeterPosX;
+        /* 0x24C */ float mLanternMeterPosY;
+        /* 0x250 */ float mOxygenMeterScale;
+        /* 0x254 */ float mOxygenMeterPosX;
+        /* 0x258 */ float mOxygenMeterPosY;
+        /* 0x250 */ uint8_t field_0x250[0x25e - 0x25C];
+        /* 0x25E */ int16_t field_0x246;
+        /* 0x260 */ int16_t field_0x248;
+        /* 0x260 */ uint8_t field_0x260[0x268 - 0x262];
+#else
+        /* 0x208 */ float mLifeGuagePosY;
+        /* 0x20C */ float mLifeGuageScale;
+        /* 0x210 */ float mHeartScale;
+        /* 0x214 */ float mLargeHeartScale;
+        /* 0x218 */ uint8_t field_0x218[0x22C - 0x218];
+        /* 0x22C */ float mLanternMeterScale;
+        /* 0x230 */ float mLanternMeterPosX;
+        /* 0x234 */ float mLanternMeterPosY;
+        /* 0x238 */ float mOxygenMeterScale;
+        /* 0x23C */ float mOxygenMeterPosX;
+        /* 0x240 */ float mOxygenMeterPosY;
+        /* 0x244 */ uint8_t field_0x244[0x246 - 0x244];
+        /* 0x246 */ int16_t field_0x246;
+        /* 0x248 */ int16_t field_0x248;
+        /* 0x24A */ uint8_t field_0x24a[0x268 - 0x24a];
+#endif
+        /* 0x268 */ float mRupeeKeyScale;
+        /* 0x26C */ float mRupeeKeyPosX;
+        /* 0x270 */ float mRupeeKeyPosY;
     } __attribute__((__packed__));
 
     extern "C"

--- a/include/tp/d_meter2_draw.h
+++ b/include/tp/d_meter2_draw.h
@@ -63,14 +63,27 @@ namespace libtp::tp::d_meter2_draw
         /* 0x178 */ libtp::tp::d_pane_class::CPaneMgr* mpHeartMask[20];
         /* 0x1C8 */ libtp::tp::d_pane_class::CPaneMgr* mpBigHeart; // Big heart that displays highest heart value.
         /* 0x1CC */ libtp::tp::d_pane_class::CPaneMgr* mpMagicParent;
+#if defined(TP_WUS2) || defined(TP_WJP)
+        /* 0x1D0 */ uint8_t unk1[0x10];
+#else
         /* 0x1D0 */ libtp::tp::d_pane_class::CPaneMgr* mpMagicBase;
         /* 0x1D4 */ libtp::tp::d_pane_class::CPaneMgr* mpMagicFrameL;
         /* 0x1D8 */ libtp::tp::d_pane_class::CPaneMgr* mpMagicMeter;
         /* 0x1DC */ libtp::tp::d_pane_class::CPaneMgr* mpMagicFrameR;
+#endif
         /* 0x1E0 */ libtp::tp::d_pane_class::CPaneMgr* mpLightDropParent;
         /* 0x1E4 */ int32_t field_0x1e4;
         /* 0x1E8 */ libtp::tp::d_pane_class::CPaneMgr* mpSIParent[2];
+#if defined(TP_WUS2) || defined(TP_WJP)
+        /* 0x1F0 */ uint8_t unk2[0x22C - 0x1F0];
+        /* 0x22C */ libtp::tp::d_pane_class::CPaneMgr* mpMagicBase;
+        /* 0x230 */ libtp::tp::d_pane_class::CPaneMgr* mpMagicFrameL;
+        /* 0x234 */ libtp::tp::d_pane_class::CPaneMgr* mpMagicMeter;
+        /* 0x238 */ libtp::tp::d_pane_class::CPaneMgr* mpMagicFrameR;
+        /* 0x23C */ uint8_t unk3[0x2B0 - 0x23C];
+#else
         /* 0x1F0 */ libtp::tp::d_pane_class::CPaneMgr* mpSIParts[16][3];
+#endif
         /* 0x2B0 */ libtp::tp::d_pane_class::CPaneMgr* mpRupeeKeyParent;
         /* 0x2B4 */ libtp::tp::d_pane_class::CPaneMgr* mpRupeeParent[3];
         /* 0x2C0 */ libtp::tp::d_pane_class::CPaneMgr* mpRupeeTexture[4][2];
@@ -106,10 +119,10 @@ namespace libtp::tp::d_meter2_draw
         /* 0x4A4 */ libtp::tp::d_pane_class::CPaneMgr* mpJujiM[5];
         /* 0x4B8 */ libtp::tp::d_pane_class::CPaneMgr* mpUzu;
         /* 0x4BC */ uint8_t field_0x4bc[0x28];
-        /* 0x4E4 */ void* mpItemBTex[2][2];     // JKRHeap*
-        /* 0x4F4 */ void* mpItemXYTex[2][2][2]; // JKRHeap*
-        /* 0x514 */ void* mpItemBPane;          // J2DPicture*
-        /* 0x518 */ void* mpItemXYPane[3];      // J2DPicture*
+        /* 0x4E4 */ libtp::tp::JUTTexture::ResTIMG* mpItemBTex[2][2];     // JKRHeap*
+        /* 0x4F4 */ libtp::tp::JUTTexture::ResTIMG* mpItemXYTex[2][2][2]; // JKRHeap*
+        /* 0x514 */ libtp::tp::J2DPicture::J2DPicture* mpItemBPane;          // J2DPicture*
+        /* 0x518 */ libtp::tp::J2DPicture::J2DPicture* mpItemXYPane[3];      // J2DPicture*
         /* 0x524 */ int32_t field_0x524[2][2];
         /* 0x534 */ uint8_t field_0x534[8];
         /* 0x53C */ void* field_0x53c;
@@ -129,15 +142,44 @@ namespace libtp::tp::d_meter2_draw
         /* 0x578 */ float field_0x578;
         /* 0x57C */ float field_0x57c;
         /* 0x580 */ float field_0x580;
-        /* 0x584 */ uint8_t field_0x584[0x78];
-        /* 0x5FC */ float field_0x5fc[3];
+#if defined(TP_WUS2) || defined(TP_WJP)
+        /* 0x584 */ uint8_t unkunk[0x608 - 0x584];
+#else
+        /* 0x584 */ float field_0x584[3];
+        /* 0x590 */ float field_0x590[3];
+        /* 0x59C */ float field_0x59c[3];
+        /* 0x5A8 */ float field_0x5a8[3];
+        /* 0x5B4 */ float field_0x5b4[3];
+        /* 0x5C0 */ float field_0x5c0[3];
+        /* 0x5CC */ float field_0x5cc[3];
+        /* 0x5D8 */ float field_0x5d8[3];
+        /* 0x5E4 */ float field_0x5e4[3];
+        /* 0x5F0 */ float field_0x5f0[3];
+        /* 0x5FC */ float mMeterAlphaRate[3];
+#endif
         /* 0x608 */ float field_0x608;
         /* 0x60C */ float field_0x60c;
+#if defined(TP_WUS2) || defined(TP_WJP)
+        /* 0x610 */ float field_0x610[2];
+        /* 0x618 */ float field_0x584[3];
+        /* 0x624 */ float field_0x590[3];
+        /* 0x630 */ float field_0x59c[3];
+        /* 0x63C */ float field_0x5a8[3];;
+        /* 0x648 */ float field_0x5b4[3];
+        /* 0x654 */ float field_0x5c0[3];
+        /* 0x660 */ float field_0x5cc[3];
+        /* 0x66C */ float field_0x5d8[3];
+        /* 0x678 */ float field_0x5e4[3];
+        /* 0x684 */ float field_0x5f0[3];
+        /* 0x690 */ float mMeterAlphaRate[3];
+        /* 0x69C */ uint8_t field_0x690[0x6AC - 0x69C];
+#else
         /* 0x610 */ float field_0x610[3];
         /* 0x61C */ float field_0x61c;
         /* 0x620 */ float field_0x620[3];
         /* 0x62C */ float field_0x62c[16];
         /* 0x66C */ float field_0x66c[16];
+#endif
         /* 0x6AC */ float field_0x6ac[3];
         /* 0x6B8 */ float field_0x6b8[3];
         /* 0x6C4 */ float field_0x6c4[3];
@@ -148,7 +190,7 @@ namespace libtp::tp::d_meter2_draw
         /* 0x6E8 */ float field_0x6e8;
         /* 0x6EC */ float field_0x6ec;
         /* 0x6F0 */ float field_0x6f0;
-        /* 0x6F4 */ float field_0x6f4;
+        /* 0x6F4 */ float mLightDropVesselScale;
         /* 0x6F8 */ float field_0x6f8;
         /* 0x6FC */ float field_0x6fc;
         /* 0x700 */ uint8_t field_0x700[0x18];
@@ -163,7 +205,11 @@ namespace libtp::tp::d_meter2_draw
         /* 0x738 */ float field_0x738;
         /* 0x73C */ uint8_t field_0x73c[4];
         /* 0x740 */ uint16_t field_0x740;
+#if defined(TP_WUS2) || defined(TP_WJP)
+        /* 0x742 */ uint16_t unkunkunk[3];
+#else
         /* 0x742 */ uint16_t field_0x742[3];
+#endif
         /* 0x748 */ uint8_t field_0x748[0xC];
         /* 0x754 */ uint16_t field_0x754;
         /* 0x756 */ uint16_t field_0x756;
@@ -222,8 +268,13 @@ namespace libtp::tp::d_meter2_draw
         /* 0x7E8 */ float field_0x7e8;
         /* 0x7EC */ float field_0x7ec;
         /* 0x7F0 */ float field_0x7f0;
+#if defined(TP_WUS2) || defined(TP_WJP)
+        /* 0x7F4 */ uint8_t unkunkunkunk[2];
+        /* 0x7F6 */ uint16_t field_0x742[3];
+#else
         /* 0x7F4 */ float field_0x7f4;
         /* 0x7F8 */ float field_0x7f8;
+#endif
         /* 0x7FC */ float field_0x7fc;
         /* 0x800 */ float field_0x800;
         /* 0x804 */ float field_0x804;


### PR DESCRIPTION
Some of the variables for Wii (the ones that start with unk...) are there for padding purposes mainly for Wii